### PR TITLE
fix: https://github.com/Tech-SoundSpire/soundspire-frontend/issues/11

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "next/core-web-vitals"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": "warn",
+    "@typescript-eslint/no-explicit-any": "warn"
+  },
+  "root": true
+} 

--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,10 @@ images: {
   ],
 },
 
+eslint: {
+  ignoreDuringBuilds: false,
+},
+
 };
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "brace-expansion": "^4.0.1",
         "next": "15.3.0",
         "react": "^18",
         "react-dom": "^18",
@@ -17,14 +18,9 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
-        "@typescript-eslint/eslint-plugin": "^8.32.0",
-        "@typescript-eslint/parser": "^8.32.0",
         "autoprefixer": "^10.0.1",
-        "eslint": "^8.57.1",
-        "eslint-config-next": "^14.2.28",
-        "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint": "^8",
+        "eslint-config-next": "^15.3.3",
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
         "typescript": "^5"
@@ -674,13 +670,43 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.28.tgz",
-      "integrity": "sha512-GQUPA1bTZy5qZdPV5MOHB18465azzhg8xm5o2SqxMF+h1rWNjB43y6xmIPHG5OV2OiU3WxuINpusXom49DdaIQ==",
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.3.tgz",
+      "integrity": "sha512-VKZJEiEdpKkfBmcokGjHu0vGDG+8CehGs90tBEy/IDoDDKGngeyIStt2MmE5FYNyU9BhgR7tybNWTAJY/30u+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob": "10.3.10"
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -1091,16 +1117,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -1755,11 +1771,13 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-3.0.1.tgz",
+      "integrity": "sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1775,14 +1793,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-4.0.1.tgz",
+      "integrity": "sha512-YClrbvTCXGe70pU2JiEiPLYXO9gQkyxYeKpJIQHVS/gOs6EWMQP2RYBwjFLNT322Ji8TOC3IMPfsYCedNpzKfA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/braces": {
@@ -2047,13 +2066,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2540,44 +2552,31 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.28",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.28.tgz",
-      "integrity": "sha512-UxJMRQ4uaEdLp3mVQoIbRIlEF0S2rTlyZhI/2yEMVdAWmgFfPY4iJZ68jCbhLvXMnKeHMkmqTGjEhFH5Vm9h+A==",
+      "version": "15.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.3.3.tgz",
+      "integrity": "sha512-QJLv/Ouk2vZnxL4b67njJwTLjTf7uZRltI0LL4GERYR4qMF5z08+gxkfODAeaK7TiC6o+cER91bDaEnwrTWV6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.28",
-        "@rushstack/eslint-patch": "^1.3.3",
+        "@next/eslint-plugin-next": "15.3.3",
+        "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.28.1",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-react": "^7.33.2",
-        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^5.0.0"
       },
       "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0",
+        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
         "typescript": ">=3.3.1"
       },
       "peerDependenciesMeta": {
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-config-next/node_modules/eslint-plugin-react-hooks": {
-      "version": "5.0.0-canary-7118f5dd7-20230705",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
-      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -3270,16 +3269,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "overrides": {
+    "brace-expansion": "^4.0.1"
+  },
   "scripts": {
     "dev": "node server.js",
     "build": "next build",
@@ -10,6 +13,7 @@
     "test": "echo \"No tests yet... but we're ready!\""
   },
   "dependencies": {
+    "brace-expansion": "^4.0.1",
     "next": "15.3.0",
     "react": "^18",
     "react-dom": "^18",
@@ -21,7 +25,7 @@
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
-    "eslint-config-next": "14.2.28",
+    "eslint-config-next": "^15.3.3",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -14,6 +14,7 @@ interface User {
   displayName?: string | null;
   email: string | null;
   photoURL?: string | null;
+  image?: string | null;
 }
 
 // Types for our profile data
@@ -90,7 +91,7 @@ export default function ProfilePage() {
                   ? user.email.split('@')[0].toLowerCase() 
                   : '',
         email: user.email || '',
-        profileImage: user.photoURL,
+        profileImage: user.photoURL || user.image || '',
       }));
     }
   }, [user]);
@@ -211,7 +212,7 @@ export default function ProfilePage() {
           ...parsedProfile,
           // Keep certain fields from auth if they're more up-to-date
           email: user.email || parsedProfile.email,
-          profileImage: user.photoURL || parsedProfile.profileImage
+          profileImage: user.photoURL || user.image || parsedProfile.profileImage
         }));
       }
     }
@@ -342,15 +343,15 @@ export default function ProfilePage() {
                 >
                   {profile.profileImage ? (
                     <Image
-                      src={isEditing ? editableProfile.profileImage : profile.profileImage}
+                      src={isEditing ? (editableProfile.profileImage || '') : (profile.profileImage || '')}
                       alt="Profile picture"
                       width={112}
                       height={112}
                       className="object-cover"
                     />
-                  ) : user?.photoURL ? (
+                  ) : user?.photoURL || user?.image ? (
                     <Image
-                      src={user.photoURL}
+                      src={user.photoURL || user.image || ''}
                       alt="Google profile picture"
                       width={112}
                       height={112}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,6 +8,8 @@ interface User {
   name: string;
   email: string;
   image?: string;
+  photoURL?: string;
+  displayName?: string | null;
   provider: 'google' | 'spotify';
   accessToken?: string;
   refreshToken?: string;


### PR DESCRIPTION
This is the fix for https://github.com/Tech-SoundSpire/soundspire-frontend/issues/11 and this also updates dependencies so as to mitigate vulnerabilities:
```
# npm audit report

brace-expansion  >=2.0.1
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
fix available via `npm audit fix --force`
Will install eslint-config-next@15.3.3, which is a breaking change
node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion
node_modules/glob/node_modules/brace-expansion
  minimatch  >=5.0.0
  Depends on vulnerable versions of brace-expansion
  node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch
  node_modules/glob/node_modules/minimatch
    @typescript-eslint/typescript-estree  >=6.16.0
    Depends on vulnerable versions of minimatch
    node_modules/@typescript-eslint/typescript-estree
      @typescript-eslint/parser  >=6.16.0
      Depends on vulnerable versions of @typescript-eslint/typescript-estree
      node_modules/@typescript-eslint/parser
        @typescript-eslint/eslint-plugin  >=6.16.0
        Depends on vulnerable versions of @typescript-eslint/parser
        Depends on vulnerable versions of @typescript-eslint/type-utils
        Depends on vulnerable versions of @typescript-eslint/utils
        node_modules/@typescript-eslint/eslint-plugin
      @typescript-eslint/type-utils  >=6.16.0
      Depends on vulnerable versions of @typescript-eslint/typescript-estree
      Depends on vulnerable versions of @typescript-eslint/utils
      node_modules/@typescript-eslint/type-utils
      @typescript-eslint/utils  >=6.16.0
      Depends on vulnerable versions of @typescript-eslint/typescript-estree
      node_modules/@typescript-eslint/utils
    glob  >=8.0.1
    Depends on vulnerable versions of minimatch
    node_modules/glob
      @next/eslint-plugin-next  14.0.5-canary.0 - 15.0.0-rc.1
      Depends on vulnerable versions of glob
      node_modules/@next/eslint-plugin-next
        eslint-config-next  14.0.5-canary.0 - 15.0.0-rc.1
        Depends on vulnerable versions of @next/eslint-plugin-next
        node_modules/eslint-config-next
      sucrase  >=3.35.0
      Depends on vulnerable versions of glob
      node_modules/sucrase
        tailwindcss  3.4.15 - 3.4.17
        Depends on vulnerable versions of sucrase
        node_modules/tailwindcss

12 low severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
  ```