### PR TITLE
feat: use gmail for actual mail auth rather than mailtrap

### DIFF
--- a/src/utils/mailer.ts
+++ b/src/utils/mailer.ts
@@ -1,6 +1,7 @@
 import nodemailer from "nodemailer";
-import dotenv from "dotenv";
-dotenv.config();
+import SMTPTransport from "nodemailer/lib/smtp-transport";
+// import dotenv from "dotenv";
+// dotenv.config();
 
 // Defining the typing for clarity and safety
 interface EmailOptions {
@@ -13,30 +14,30 @@ interface EmailOptions {
 export const sendEmail = async ({ email, emailType, link }: EmailOptions) => {
   try {
     const transport = nodemailer.createTransport({
-     host: process.env.MAILTRAP_HOST,
-  port: parseInt(process.env.MAILTRAP_PORT || "2525"),
-  auth: {
-    user: process.env.MAILTRAP_USER,
-    pass: process.env.MAILTRAP_PASSWORD,
+      service: process.env.GMAIL_SERVICE,
+      host: process.env.GMAIL_HOST,
+      port: Number(process.env.GMAIL_SMTP_PORT),
+      secure: false, // true for 465, false for other ports
+      auth: {
+        user: process.env.GMAIL_USER,
+        pass: process.env.GMAIL_APP_PASSWORD,
       },
-    });
+    } as SMTPTransport.Options);
 
     let subject = "";
     let html = "";
 
     //if the type is verify we will send two copies
     if (emailType === "VERIFY") {
-
-      subject = "Verify your email";
+      subject = "SoundSpire - Verify your email!";
       html = `
-        <h2>Welcome to Our App!</h2>
+        <h2>Welcome to SoundSpire!</h2>
         <p>Please verify your email by clicking the link below:</p>
         <a href="${link}">Verify Email</a>
         <p>This link will expire in 20 minutes.</p>
       `;
     } else if (emailType === "RESET") {
-   
-      subject = "Reset your password";
+      subject = "SoundSpire - Reset your password";
       html = `
         <h2>Password Reset Request</h2>
         <p>Click below to reset your password:</p>
@@ -46,7 +47,7 @@ export const sendEmail = async ({ email, emailType, link }: EmailOptions) => {
     }
 
     const mailOptions = {
-      from: '"Maddison Foo Koch" <maddison53@ethereal.email>',
+      from: `"SoundSpire" <${process.env.GMAIL_USER}>`,
       to: email,
       subject,
       html,
@@ -58,7 +59,7 @@ export const sendEmail = async ({ email, emailType, link }: EmailOptions) => {
 
     return mailResponse;
   } catch (error: unknown) {
-    if(error instanceof Error){
+    if (error instanceof Error) {
       console.error("❌ Error sending email:", error.message);
       throw new Error(error.message);
     }


### PR DESCRIPTION
Make use of gmail SMTP rather than mailtrap. Mailtrap is okay for testing, but not for actual production use cases.
There are updates required to the env variables alongside these changes, these will be shared.