### PR TITLE
Fix: apply default profile image for new users

### DIFF
--- a/src/utils/userProfileImageUtils.ts
+++ b/src/utils/userProfileImageUtils.ts
@@ -1,17 +1,23 @@
-// Convert S3 path to API URL
-export const getImageUrl = (
-    s3Path: string | undefined | null
-): string | undefined => {
-    if (!s3Path) return;
-    // If it's already a URL, return it
-    if (s3Path.startsWith("http")) {
-        return s3Path;
-    }
+// utils/userProfileImageUtils.ts
 
-    // If it's already an API path — return as-is
-    if (s3Path.startsWith("/api/")) {
-        return s3Path;
-    }
+// Default profile image path on S3
+export const DEFAULT_PROFILE_IMAGE =
+    "s3://soundspirewebsiteassets/images/placeholder.jpg";
+
+// SoundSpire logo path on S3
+export const SOUNDSPIRE_LOGO =
+    "s3://soundspirewebsiteassets/assets/ss_logo.png";
+
+// Convert S3 path or relative path to API URL
+export const getImageUrl = (s3Path?: string | null): string => {
+    // If no path provided, fallback to default profile image
+    if (!s3Path) return getDefaultProfileImageUrl();
+
+    // If it's already a full URL, return as-is
+    if (s3Path.startsWith("http")) return s3Path;
+
+    // If it's already an API path, return as-is
+    if (s3Path.startsWith("/api/")) return s3Path;
 
     // If it's an S3 path, normalize it
     if (s3Path.startsWith("s3://")) {
@@ -19,11 +25,8 @@ export const getImageUrl = (
         if (match) {
             let path = match[1]; // e.g. "assets/ss_logo.png" or "images/placeholder.jpg"
 
-            // Always ensure path is under /api/images/...
-            // Even if it's "assets/", backend will look under "images/assets/..."
-            if (!path.startsWith("images/")) {
-                path = `images/${path}`;
-            }
+            // Ensure path is under "images/"
+            if (!path.startsWith("images/")) path = `images/${path}`;
 
             return `/api/${path}`;
         }
@@ -35,25 +38,16 @@ export const getImageUrl = (
         s3Path.startsWith("reviews/") ||
         s3Path.startsWith("images/")
     ) {
-        // Prefix with /api/images/ to match backend
         return `/api/images/${s3Path}`;
     }
 
-    // Default fallback
+    // Default fallback for any other string
     return `/api/images/${s3Path}`;
 };
 
-// Default profile image path
-export const DEFAULT_PROFILE_IMAGE =
-    "s3://soundspirewebsiteassets/images/placeholder.jpg";
-
-// SoundSpire logo path
-export const SOUNDSPIRE_LOGO =
-    "s3://soundspirewebsiteassets/assets/ss_logo.png";
-
 // Helper to get the default profile image URL
-export const getDefaultProfileImageUrl = () =>
-    getImageUrl(DEFAULT_PROFILE_IMAGE);
+export const getDefaultProfileImageUrl = (): string =>
+    `/api/images/images/placeholder.jpg`; // or use getImageUrl(DEFAULT_PROFILE_IMAGE)
 
 // Helper to get the logo URL
-export const getLogoUrl = () => getImageUrl(SOUNDSPIRE_LOGO);
+export const getLogoUrl = (): string => getImageUrl(SOUNDSPIRE_LOGO);


### PR DESCRIPTION
Fixes #36

### Changes
- Applied default placeholder profile image when a user signs up without uploading one
- Centralized default avatar logic using `userProfileImageUtils`
- Ensured consistent profile image handling for new users

### Result
- New users always see a default profile picture
- No empty or broken avatar states
